### PR TITLE
Build warning fixed, traffic param removed, log level option added

### DIFF
--- a/example/client/client.c
+++ b/example/client/client.c
@@ -153,7 +153,6 @@ int main(int argc, char **argv)
         printf("  --log <file>    - Set log file.\n");
         printf("  --nolog         - Redirect all log messages to stdout.\n");
         printf("  --daemonize     - Daemonize client.\n");
-        printf("  --traffic       - Get current traffic (Administration only).\n");
         printf("\n");
         exit(1);
     }
@@ -162,7 +161,6 @@ int main(int argc, char **argv)
     const char *log_file    = NULL;
     int nolog = 0;
     int daemonize = 0;
-    int traffic   = 0;
 
     int i;
     for(i = 0; i < argc; i++) {
@@ -174,8 +172,6 @@ int main(int argc, char **argv)
             nolog = 1;
         else if(strcmp(argv[i], "--daemonize") == 0)
             daemonize = 1;
-        else if(strcmp(argv[i], "--traffic") == 0)
-            traffic = 1;
     }
 
     if(config_file == NULL) {
@@ -206,7 +202,6 @@ int main(int argc, char **argv)
     gci.callback.traffic       = callback_traffic;
     gci.callback.account_set   = callback_account_set;
     gci.callback.account_exists= callback_account_exists;
-    gci.traffic                = traffic == 1 ? 1 : 0;
 
     gc = gc_init(&gci);
     if(gc == NULL) {

--- a/example/client/client.c
+++ b/example/client/client.c
@@ -152,6 +152,8 @@ int main(int argc, char **argv)
         printf("  --config <file> - Set configuration file.\n");
         printf("  --log <file>    - Set log file.\n");
         printf("  --nolog         - Redirect all log messages to stdout.\n");
+        printf("  --loglevel      - Default is debug. One of the following:\n");
+        printf("                    trace|debug|info|notice|warning|error|critical|alert|emerg.\n");
         printf("  --daemonize     - Daemonize client.\n");
         printf("\n");
         exit(1);
@@ -159,6 +161,7 @@ int main(int argc, char **argv)
 
     const char *config_file = NULL;
     const char *log_file    = NULL;
+    const char *log_level   = "debug";
     int nolog = 0;
     int daemonize = 0;
 
@@ -172,6 +175,8 @@ int main(int argc, char **argv)
             nolog = 1;
         else if(strcmp(argv[i], "--daemonize") == 0)
             daemonize = 1;
+        else if(strcmp(argv[i], "--loglevel") == 0 && (i + 1) < argc)
+            log_level = argv[i + 1];
     }
 
     if(config_file == NULL) {
@@ -196,12 +201,21 @@ int main(int argc, char **argv)
     gci.loop                   = ev_default_loop(0);
     gci.cfgfile                = config_file;
     gci.logfile                = log_file;
-    gci.loglevel               = LOG_TRACE;
     gci.callback.state_changed = callback_state_changed;
     gci.callback.login         = callback_login;
     gci.callback.traffic       = callback_traffic;
     gci.callback.account_set   = callback_account_set;
     gci.callback.account_exists= callback_account_exists;
+
+    if(strcmp(log_level,      "trace")   == 0) gci.loglevel = LOG_TRACE;
+    else if(strcmp(log_level, "info")    == 0) gci.loglevel = LOG_INFO;
+    else if(strcmp(log_level, "notice")  == 0) gci.loglevel = LOG_NOTICE;
+    else if(strcmp(log_level, "warning") == 0) gci.loglevel = LOG_WARNING;
+    else if(strcmp(log_level, "error")   == 0) gci.loglevel = LOG_ERR;
+    else if(strcmp(log_level, "crit")    == 0) gci.loglevel = LOG_CRIT;
+    else if(strcmp(log_level, "alert")   == 0) gci.loglevel = LOG_ALERT;
+    else if(strcmp(log_level, "emerg")   == 0) gci.loglevel = LOG_EMERG;
+    else gci.loglevel = LOG_DEBUG;
 
     gc = gc_init(&gci);
     if(gc == NULL) {

--- a/src/include/gcapi.h
+++ b/src/include/gcapi.h
@@ -126,7 +126,6 @@ struct gc_init_s {
     const char     *cfgfile;                            /**< Configuration file. */
     const char     *logfile;                            /**< Log file. */
     enum loglevel_e loglevel;                           /**< Log level. */
-    int             traffic;                            /**< Traffic command. */
 
     struct {
         void (*state_changed)(struct gc_s *gc, enum gc_state_e state);       /**< Upstream socket state cb. */


### PR DESCRIPTION
- build warning removed by adding m4 directory
- traffic parameter removed as it's unused
- added option to set log level